### PR TITLE
List also a UI port in the K8s service

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -443,6 +443,7 @@ class AlertmanagerCharm(CharmBase):
         """Fix the Kubernetes service that was setup by Juju with correct port numbers"""
         if self.unit.is_leader() and not self._stored.k8s_service_patched:
             service_ports = [
+                (f"{self.app.name}-ui", self.api_port, self.api_port),
                 (f"{self.app.name}-api", self.api_port, self.api_port),
                 (f"{self.app.name}-ha", self._ha_port, self._ha_port),
             ]


### PR DESCRIPTION
While it is true that API and UI port in Alertmanager are the same, this is not self-evident and a seldom known to users (who almost never interact with the alertmanager API, but rather the UI).

This commit lists a dedicated `-ui` port for Alertmanager, with the same `9093` port as the `-api` one.