### PR TITLE
fix doc and type hints

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,10 +57,12 @@ pip install --upgrade -r requirements.txt
 
 ### Testing
 ```shell
-tox -e prettify  # update your code according to linting rules
-tox -e lint      # code style
-tox -e static    # static analysis
-tox -e unit      # unit tests
+tox -e fmt              # update your code according to linting rules
+tox -e lint             # code style
+tox -e static           # static analysis
+tox -e unit             # unit tests
+tox -e integration      # integration tests
+tox -e integration-lma  # integration tests for the lma-light bundle
 ```
 
 tox creates virtual environment for every tox environment defined in

--- a/src/charm.py
+++ b/src/charm.py
@@ -119,10 +119,11 @@ class AlertmanagerCharm(CharmBase):
         return self._api_port
 
     @property
-    def peer_relation(self) -> Optional[Relation]:
+    def peer_relation(self) -> Relation:
         """Helper function for obtaining the peer relation object.
 
-        Returns: peer relation object; returns None if called too early, e.g. during install.
+        Returns: peer relation object
+        (NOTE: would return None if called too early, e.g. during install).
         """
         return self.model.get_relation(self._peer_relation_name)
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -85,7 +85,11 @@ class TestWithInitialHooks(unittest.TestCase):
         self.assertTrue(service.is_running())
 
     def test_relation_data_provides_public_address(self):
-        rel = self.harness.charm.framework.model.get_relation("alerting", self.relation_id)
+        # to suppress mypy error: Item "None" of "Optional[Any]" has no attribute "get_relation"
+        model = self.harness.charm.framework.model
+        assert model is not None
+
+        rel = model.get_relation("alerting", self.relation_id)
         expected_address = "1.1.1.1:{}".format(self.harness.charm.alertmanager_provider.api_port)
         self.assertEqual({"public_address": expected_address}, rel.data[self.harness.charm.unit])
 

--- a/tox.ini
+++ b/tox.ini
@@ -91,7 +91,8 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    # git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
 commands =
@@ -103,7 +104,8 @@ lma_bundle_dir = {envtmpdir}/lma-light-bundle
 deps =
     # deps from lma-bundle - these are needed here because will be running pytest on lma-bundle
     jinja2
-    git+https://github.com/juju/python-libjuju.git
+    # git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
 allowlist_externals =


### PR DESCRIPTION
- list out `tox` commands for running integration tests.
- appease mypy, at least partially, until types are [fixed in OF](https://github.com/canonical/operator/pull/664)
- use released python-libjuju from pypi instead of repo main (there was a regression recently that prompted this change)