### PR TITLE
add image sha to metadata

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -27,7 +27,7 @@ resources:
   alertmanager-image:
     type: oci-image
     description: OCI image for alertmanager
-    upstream-source: ubuntu/prometheus-alertmanager@sha256:30489547ce93a38e3cb3c76d102886e12a72145727f08ff690d2da0db697313d
+    upstream-source: ubuntu/prometheus-alertmanager:0.21-20.04_beta
 provides:
   alerting:
     # The provider (alertmanager) adds the following key-value pair to the relation data bag of

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -27,7 +27,7 @@ resources:
   alertmanager-image:
     type: oci-image
     description: OCI image for alertmanager
-    upstream-source: ubuntu/prometheus-alertmanager
+    upstream-source: ubuntu/prometheus-alertmanager@sha256:30489547ce93a38e3cb3c76d102886e12a72145727f08ff690d2da0db697313d
 provides:
   alerting:
     # The provider (alertmanager) adds the following key-value pair to the relation data bag of


### PR DESCRIPTION
This PR introduces a version pinning for the default OCI image used by the charm.

- [x] specify sha for the upstream-source
- [x] use upstrem-source in integration tests when building charm locally
- [ ] document it in README.md

In the future this may also be handy for auto-publishing to charmhub.